### PR TITLE
Updates CRD name to whereabouts.cni.cncf.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can install this plugin with a Daemonset, using:
 
 ```
 git clone https://github.com/dougbtv/whereabouts && cd whereabouts
-kubectl apply -f ./doc/daemonset-install.yaml -f ./doc/whereabouts.cni.k8s.io_ippools.yaml
+kubectl apply -f ./doc/daemonset-install.yaml -f ./doc/whereabouts.cni.cncf.io_ippools.yaml
 ```
 
 *NOTE*: This daemonset is for use with Kubernetes version 1.16 and later. It may also be useful with previous versions, however you'll need to change the `apiVersion` of the daemonset in the provided yaml, [see the deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).

--- a/doc/daemonset-install.yaml
+++ b/doc/daemonset-install.yaml
@@ -24,7 +24,7 @@ metadata:
   name: whereabouts-cni
 rules:
 - apiGroups:
-  - whereabouts.cni.k8s.io
+  - whereabouts.cni.cncf.io
   resources:
   - ippools
   verbs:

--- a/doc/whereabouts.cni.cncf.io_ippools.yaml
+++ b/doc/whereabouts.cni.cncf.io_ippools.yaml
@@ -1,11 +1,12 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: ippools.whereabouts.cni.k8s.io
+  name: ippools.whereabouts.cni.cncf.io
 spec:
-  group: whereabouts.cni.k8s.io
+  group: whereabouts.cni.cncf.io
   names:
     kind: IPPool
     plural: ippools

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 	google.golang.org/grpc v1.23.0 // indirect
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d

--- a/pkg/api/v1alpha1/groupversion_info.go
+++ b/pkg/api/v1alpha1/groupversion_info.go
@@ -1,6 +1,6 @@
 // Package v1alpha1 contains API Schema definitions for the whereabouts v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=whereabouts.cni.k8s.io
+// +groupName=whereabouts.cni.cncf.io
 package v1alpha1
 
 import (
@@ -10,7 +10,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "whereabouts.cni.k8s.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "whereabouts.cni.cncf.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}


### PR DESCRIPTION
Correctly sets the whereabouts CRD namespace, given input from Weibin in this pastebin @ http://pastebin.test.redhat.com/843561