### PR TITLE
Bug 1836405: Updates for excluding network address

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 reviewers:
+  - aneeshkp
   - dougbtv
   - dcbw
   - squeed
@@ -6,6 +7,7 @@ reviewers:
   - fepan
   - s1061123
 approvers:
+  - aneeshkp
   - dougbtv
   - dcbw
   - squeed

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Three parameters are required:
 * `type`: This should be set to `whereabouts`.
 * `range`: This specifies the range in which IP addresses will be allocated.
 
-In this case the `range` is set to `192.168.2.225/28`, this will allocate IP addresses in the range
+In this case the `range` is set to `192.168.2.225/28`, this will allocate IP addresses in the range excluding the first network address and the last broadcast address
 
 If you need a tool to figure out the range of a given CIDR address, try this online tool, [subnet-calculator.com](http://www.subnet-calculator.com/).
 

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -118,7 +118,6 @@ var _ = Describe("Whereabouts operations", func() {
 		ipRange := "192.168.1.0/24"
 		ipGateway := "192.168.10.1"
 		expectedAddress := "192.168.1.1/24"
-
 		AllocateAndReleaseAddressesTest(ipVersion, ipRange, ipGateway, []string{expectedAddress}, whereaboutstypes.DatastoreETCD)
 
 		ipVersion = "6"
@@ -277,7 +276,7 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
 				Version: "4",
-				Address: mustCIDR("192.168.1.44/28"),
+				Address: mustCIDR("192.168.1.33/28"),
 				Gateway: net.ParseIP("192.168.1.1"),
 			}))
 
@@ -530,6 +529,5 @@ func mustCIDR(s string) net.IPNet {
 	if err != nil {
 		Fail(err.Error())
 	}
-
 	return *n
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1 // indirect

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -66,7 +66,9 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 	firstip := rangeStart
 	var lastip net.IP
 	if rangeEnd != nil {
-		lastip = rangeEnd
+		end := IPToBigInt(rangeEnd)
+		end = end.Add(end, big.NewInt(1))
+		lastip = BigIntToIP(*end)
 	} else {
 		var err error
 		_, lastip, err = GetIPRange(rangeStart, ipnet)

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -2,6 +2,7 @@ package allocate
 
 import (
 	"fmt"
+	"math/big"
 	"net"
 	"testing"
 
@@ -15,34 +16,117 @@ func TestAllocate(t *testing.T) {
 }
 
 var _ = Describe("Allocation operations", func() {
-	It("creates an IPv4 range properly", func() {
+	It("creates an IPv4 range properly for 30 bits network address", func() {
+
+		ip, ipnet, err := net.ParseCIDR("192.168.21.100/30")
+		ip, _ = AddressRange(ipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fmt.Sprint(firstip)).To(Equal("192.168.21.101"))
+		Expect(fmt.Sprint(lastip)).To(Equal("192.168.21.102"))
+
+	})
+	It("creates an IPv4 range properly for 24 bits network address with different range start", func() {
 
 		ip, ipnet, err := net.ParseCIDR("192.168.2.200/24")
+		ip = net.ParseIP("192.168.2.23") // range start
+
 		Expect(err).NotTo(HaveOccurred())
 
-		firstip, lastip, err := GetIPRange(ip, *ipnet)
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.0"))
-		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.255"))
+		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.23"))
+		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.254"))
+
+	})
+	It("creates an IPv4 range properly for 27 bits network address", func() {
+
+		ip, ipnet, err := net.ParseCIDR("192.168.2.200/27")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.193"))
+		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.222"))
+
+	})
+	It("creates an IPv4 range properly for 24 bits network address", func() {
+
+		ip, ipnet, err := net.ParseCIDR("192.168.2.200/24")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.254"))
 
 	})
 	// Handy IPv6 CIDR calculator: https://www.ultratools.com/tools/ipv6CIDRToRangeResult?ipAddress=2001%3A%3A0%2F28
-	It("creates an IPv6 range properly", func() {
+	It("creates an IPv6 range properly for 116 bits network address", func() {
 
 		ip, ipnet, err := net.ParseCIDR("2001::0/116")
+		ip, _ = AddressRange(ipnet)
+
 		Expect(err).NotTo(HaveOccurred())
 
-		firstip, lastip, err := GetIPRange(ip, *ipnet)
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(fmt.Sprint(firstip)).To(Equal("2001::"))
-		Expect(fmt.Sprint(lastip)).To(Equal("2001::fff"))
+		Expect(fmt.Sprint(firstip)).To(Equal("2001::1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001::ffe"))
+
+	})
+	It("creates an IPv6 range properly for 96 bits network address", func() {
+
+		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::ffff:fffe"))
+
+	})
+	It("creates an IPv6 range properly for 64 bits network address", func() {
+
+		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/64")
+		ip, _ = AddressRange(ipnet)
+
+		Expect(err).NotTo(HaveOccurred())
+
+		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12:ffff:ffff:ffff:fffe"))
+
+	})
+	It("do not fail when the mask meets minimum required", func() {
+
+		badip, badipnet, err := net.ParseCIDR("192.168.21.100/30")
+		badip, _ = AddressRange(badipnet)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, _, err = GetIPRange(badip, *badipnet)
+		Expect(err).NotTo(HaveOccurred())
 
 	})
 	It("fails when the mask is too short", func() {
 
-		badip, badipnet, err := net.ParseCIDR("10.0.0.100/2")
+		badip, badipnet, err := net.ParseCIDR("192.168.21.100/31")
+		badip, _ = AddressRange(badipnet)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, _, err = GetIPRange(badip, *badipnet)
@@ -52,3 +136,50 @@ var _ = Describe("Allocation operations", func() {
 	})
 
 })
+
+func AddressRange(network *net.IPNet) (net.IP, net.IP) {
+	// the first IP is easy
+	firstIP := network.IP
+
+	// the last IP is the network address OR NOT the mask address
+	prefixLen, bits := network.Mask.Size()
+	if prefixLen == bits {
+		// Easy!
+		// But make sure that our two slices are distinct, since they
+		// would be in all other cases.
+		lastIP := make([]byte, len(firstIP))
+		copy(lastIP, firstIP)
+		return firstIP, lastIP
+	}
+
+	firstIPInt, bits := ipToInt(firstIP)
+	hostLen := uint(bits) - uint(prefixLen)
+	lastIPInt := big.NewInt(1)
+	lastIPInt.Lsh(lastIPInt, hostLen)
+	lastIPInt.Sub(lastIPInt, big.NewInt(1))
+	lastIPInt.Or(lastIPInt, firstIPInt)
+
+	return firstIP, intToIP(lastIPInt, bits)
+}
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		panic(fmt.Errorf("Unsupported address length %d", len(ip)))
+	}
+}
+
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return net.IP(ret)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,6 +123,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 		}
 		n.IPAM.Range = ipNet.String()
 		if n.IPAM.RangeStart == nil {
+			firstip = net.ParseIP(firstip.Mask(ipNet.Mask).String()) // if range_start is not net then pick the first network address
 			n.IPAM.RangeStart = firstip
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Allocation operations", func() {
 		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
 		Expect(ipamconfig.EtcdHost).To(Equal("foo"))
 		Expect(ipamconfig.Range).To(Equal("192.168.1.0/24"))
+		Expect(ipamconfig.RangeStart).To(Equal(net.ParseIP("192.168.1.5")))
+		Expect(ipamconfig.RangeEnd).To(Equal(net.ParseIP("192.168.1.25")))
 		Expect(ipamconfig.Gateway).To(Equal(net.ParseIP("192.168.10.1")))
 
 	})
@@ -67,7 +69,8 @@ var _ = Describe("Allocation operations", func() {
       "ipam": {
         "configuration_path": "/tmp/whereabouts.conf",
         "type": "whereabouts",
-        "range": "192.168.1.5-192.168.1.25/24",
+        "range": "192.168.2.230/24",
+        "range_start": "192.168.2.223",
         "gateway": "192.168.10.1"
       }
       }`
@@ -76,7 +79,8 @@ var _ = Describe("Allocation operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamconfig.LogLevel).To(Equal("debug"))
 		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
-		Expect(ipamconfig.Range).To(Equal("192.168.1.0/24"))
+		Expect(ipamconfig.Range).To(Equal("192.168.2.0/24"))
+		Expect(ipamconfig.RangeStart.String()).To(Equal("192.168.2.223"))
 		// Gateway should remain unchanged from conf due to preference for primary config
 		Expect(ipamconfig.Gateway).To(Equal(net.ParseIP("192.168.10.1")))
 		Expect(ipamconfig.Datastore).To(Equal("kubernetes"))


### PR DESCRIPTION
Big thanks Aneesh! Has fixes for BZ 1836405 to exclude the network address, and includes thorough testing.

Additionally includes commit for changes to `range_end should be treated as inclusive when iterating for ip assignments`