### PR TITLE
Updating ose-multus-whereabouts-ipam-cni builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is used for building for OpenShift
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 as rhel8
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS rhel8
 ADD . /go/src/github.com/dougbtv/whereabouts
 WORKDIR /go/src/github.com/dougbtv/whereabouts
 ENV CGO_ENABLED=1
@@ -8,7 +8,7 @@ ENV VERSION=rhel8 COMMIT=unset
 RUN go build -mod vendor -o bin/whereabouts cmd/whereabouts.go
 WORKDIR /
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.6 AS rhel7
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.7 AS rhel7
 ADD . /go/src/github.com/dougbtv/whereabouts
 WORKDIR /go/src/github.com/dougbtv/whereabouts
 ENV CGO_ENABLED=1
@@ -16,7 +16,7 @@ ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/whereabouts cmd/whereabouts.go
 WORKDIR /
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 RUN mkdir -p /usr/src/whereabouts/images && \
        mkdir -p /usr/src/whereabouts/bin && \
        mkdir -p /usr/src/whereabouts/rhel7/bin && \


### PR DESCRIPTION
Updating ose-multus-whereabouts-ipam-cni builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-multus-whereabouts-ipam-cni.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
