### PR TITLE
Excluded subnet handling for ipv6

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -534,6 +534,67 @@ var _ = Describe("Whereabouts operations", func() {
 
 	})
 
+	It("excludes a range of IPv6 addresses", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		conf := fmt.Sprintf(`{
+      "cniVersion": "0.3.1",
+      "name": "mynet",
+      "type": "ipvlan",
+      "master": "foo0",
+      "ipam": {
+        "type": "whereabouts",
+        "log_file" : "/tmp/whereabouts.log",
+				"log_level" : "debug",
+        "etcd_host": "%s",
+        "range": "2001::1/116",
+        "exclude": [
+          "2001::0/128",
+          "2001::1/128",
+          "2001::2/128"
+        ],
+        "gateway": "2001::f:1",
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    }`, etcdHost)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// fmt.Printf("!bang raw: %s\n", raw)
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Gomega is cranky about slices with different caps
+		Expect(*result.IPs[0]).To(Equal(
+			current.IPConfig{
+				Version: "6",
+				Address: mustCIDR("2001::3/116"),
+				Gateway: net.ParseIP("2001::f:1"),
+			}))
+
+		// Release the IP
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
 	It("can still assign static parameters", func() {
 		const ifname string = "eth0"
 		const nspath string = "/some/where"

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -134,7 +134,7 @@ MAINITERATION:
 
 		// Lastly, we need to check if this IP is within the range of excluded subnets
 		for _, subnet := range excluded {
-			if subnet.Contains(BigIntToIP(*i).To4()) {
+			if subnet.Contains(BigIntToIP(*i).To16()) {
 				continue MAINITERATION
 			}
 		}


### PR DESCRIPTION
Excluded subnets was handled for ipv4. This fix handles ipv6 as well.
Adds test to check for excluding IPv6 addresses

As reported in: dougbtv/whereabouts#71

