### PR TITLE
Bug 1898672: Removes error when deallocating IP errors out, instead just warns [backport 4.6]

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -79,8 +79,8 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
 	if err != nil {
-		logging.Errorf("Error deallocating IP: %s", err)
-		return fmt.Errorf("Error deallocating IP: %s", err)
+		logging.Verbosef("WARNING: Problem deallocating IP: %s", err)
+		// return fmt.Errorf("Error deallocating IP: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
Backport #39 to 4.6