### PR TITLE
Bug 1898613: Logic for IPv6 assignment should not omit the broadcast addresses

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -595,6 +595,63 @@ var _ = Describe("Whereabouts operations", func() {
 
 	})
 
+	It("excludes a range of IPv6 addresses, omitting broadcast", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		conf := fmt.Sprintf(`{
+      "cniVersion": "0.3.1",
+      "name": "mynet",
+      "type": "ipvlan",
+      "master": "foo0",
+      "ipam": {
+        "type": "whereabouts",
+        "log_file" : "/tmp/whereabouts.log",
+				"log_level" : "debug",
+        "etcd_host": "%s",
+				"range": "caa5::0/112",
+        "exclude": ["caa5::0/113"],
+        "gateway": "2001::f:1",
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    }`, etcdHost)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// fmt.Printf("!bang raw: %s\n", raw)
+		Expect(strings.Index(string(raw), "\"version\":")).Should(BeNumerically(">", 0))
+
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Gomega is cranky about slices with different caps
+		Expect(*result.IPs[0]).To(Equal(
+			current.IPConfig{
+				Version: "6",
+				Address: mustCIDR("caa5::8000/112"),
+				Gateway: net.ParseIP("2001::f:1"),
+			}))
+
+		// Release the IP
+		err = testutils.CmdDelWithArgs(args, func() error {
+			return cmdDel(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
 	It("can still assign static parameters", func() {
 		const ifname string = "eth0"
 		const nspath string = "/some/where"

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -119,15 +119,10 @@ MAINITERATION:
 		}
 
 		// We can try to work with the current IP
-		// However, let's skip 0-based addresses
-		// So go ahead and continue if the 4th/16th byte equals 0
+		// However, let's skip 0-based addresses in IPv4
 		ipbytes := i.Bytes()
 		if isIntIPv4(i) {
 			if ipbytes[5] == 0 {
-				continue
-			}
-		} else {
-			if ipbytes[15] == 0 {
 				continue
 			}
 		}
@@ -201,8 +196,12 @@ func GetIPRange(ip net.IP, ipnet net.IPNet) (net.IP, net.IP, error) {
 	// remove network and broadcast address from the  range
 	var incIP big.Int
 	incIP.SetInt64(1)
-	lowestiplong.Add(&lowestiplong, &incIP)   // fixes to remove network address
-	highestiplong.Sub(&highestiplong, &incIP) //fixes to remove broadcast address
+	// removes network address
+	lowestiplong.Add(&lowestiplong, &incIP)
+	// remove broadcast address, only when IPv4 (IPv6 doesn't have broadcast addresses)
+	if IsIPv4(ip) {
+		highestiplong.Sub(&highestiplong, &incIP)
+	}
 
 	// Convert to net.IPs
 	firstip := BigIntToIP(lowestiplong)

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Allocation operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(fmt.Sprint(firstip)).To(Equal("2001::1"))
-		Expect(fmt.Sprint(lastip)).To(Equal("2001::ffe"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001::fff"))
 
 	})
 	It("creates an IPv6 range properly for 96 bits network address", func() {
@@ -96,7 +96,7 @@ var _ = Describe("Allocation operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
-		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::ffff:fffe"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::ffff:ffff"))
 
 	})
 	It("creates an IPv6 range properly for 64 bits network address", func() {
@@ -110,7 +110,7 @@ var _ = Describe("Allocation operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
-		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12:ffff:ffff:ffff:fffe"))
+		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12:ffff:ffff:ffff:ffff"))
 
 	})
 	It("do not fail when the mask meets minimum required", func() {


### PR DESCRIPTION
This removes the logic that was IPv4 based for removing the broadcast address.

[IPv6 does not implement broadcast](https://en.wikipedia.org/wiki/IPv6_address#Addressing_methods).

It also adds a unit test to validate that, as well as updates some checks which wrongly assumed the broadcast address omission.