### PR TITLE
Configurable sleep_for_race parameter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,9 +10,9 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	types020 "github.com/containernetworking/cni/pkg/types/020"
+	"github.com/imdario/mergo"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
-	"github.com/imdario/mergo"
 )
 
 // canonicalizeIP makes sure a provided ip is in standard form
@@ -36,7 +36,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 	n := types.Net{
 		IPAM: &types.IPAMConfig{
 			OverlappingRanges: true,
-			SleepForRace:      false,
+			SleepForRace:      0,
 		},
 	}
 	if err := json.Unmarshal(bytes, &n); err != nil {

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -502,8 +502,8 @@ RETRYLOOP:
 		}
 
 		// Manual race condition testing
-		if ipamConf.SleepForRace {
-			time.Sleep(20 * time.Second)
+		if ipamConf.SleepForRace > 0 {
+			time.Sleep(time.Duration(ipamConf.SleepForRace) * time.Second)
 		}
 
 		err = pool.Update(requestCtx, usereservelist)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -52,7 +52,7 @@ type IPAMConfig struct {
 	LogFile             string            `json:"log_file"`
 	LogLevel            string            `json:"log_level"`
 	OverlappingRanges   bool              `json:"enable_overlapping_ranges,omitempty"`
-	SleepForRace        bool              `json:"sleep_for_race,omitempty"`
+	SleepForRace        int               `json:"sleep_for_race,omitempty"`
 	Gateway             net.IP
 	Kubernetes          KubernetesConfig `json:"kubernetes,omitempty"`
 	ConfigurationPath   string           `json:"configuration_path"`


### PR DESCRIPTION
Updates sleep_for_race parameter so we can use it in e2e tests and specify the sleep amount.