### PR TITLE
Bug 2050409: ip-reconciler should have known errors from api server on instantiation

### DIFF
--- a/doc/crds/ip-reconciler-job.yaml
+++ b/doc/crds/ip-reconciler-job.yaml
@@ -7,10 +7,16 @@ metadata:
     tier: node
     app: whereabouts
 spec:
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
   schedule: "*/5 * * * *"
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
+        metadata:
+          labels:
+            app: whereabouts
         spec:
           priorityClassName: "system-node-critical"
           serviceAccountName: whereabouts


### PR DESCRIPTION
This is a WIP intended to see how much this impacts CI for the moment. 

Generally has a set of known errors that cause the reconciler to exit 0 when they're detected.