### PR TITLE
OCPBUGS-2948: skip iterating over excluded ranges

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -222,6 +222,15 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 		for _, subnet := range excluded {
 			if subnet.Contains(i) {
 				isAddrExcluded = true
+				firstExcluded, _, _ := net.ParseCIDR(subnet.String())
+				_, lastExcluded, _ := GetIPRange(firstExcluded, *subnet)
+				if i.To4() != nil {
+					// exclude broadcast address
+					i = IPAddOffset(lastExcluded, uint64(1))
+				} else {
+					i = lastExcluded
+				}
+				logging.Debugf("excluding %v and moving to the next available ip", subnet)
 			}
 		}
 		if isAddrExcluded {

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -224,13 +224,15 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 				isAddrExcluded = true
 				firstExcluded, _, _ := net.ParseCIDR(subnet.String())
 				_, lastExcluded, _ := GetIPRange(firstExcluded, *subnet)
-				if i.To4() != nil {
-					// exclude broadcast address
-					i = IPAddOffset(lastExcluded, uint64(1))
-				} else {
-					i = lastExcluded
+				if lastExcluded != nil {
+					if i.To4() != nil {
+						// exclude broadcast address
+						i = IPAddOffset(lastExcluded, uint64(1))
+					} else {
+						i = lastExcluded
+					}
+					logging.Debugf("excluding %v and moving to the next available ip: %v", subnet, i)
 				}
-				logging.Debugf("excluding %v and moving to the next available ip", subnet)
 			}
 		}
 		if isAddrExcluded {

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -336,7 +336,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.0/30"}
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
 
 	})
@@ -351,7 +351,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2:1/126"}
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
 
 	})

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -326,6 +326,36 @@ var _ = Describe("Allocation operations", func() {
 
 	})
 
+	It("can IterateForAssignment on an IPv4 address excluding a range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"192.168.0.0/30"}
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
+
+	})
+
+	It("can IterateForAssignment on an IPv6 address excluding a range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("100::2:1/125")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"100::2:1/126"}
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
+
+	})
+
 	It("creates an IPv6 range properly for 96 bits network address", func() {
 
 		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")


### PR DESCRIPTION
Skip iterating over excluded ranges while looking for a suitable IP candidate.