### PR TITLE
OCPBUGS-3943: Excluded ranges bug (#282)

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -222,6 +222,17 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 		for _, subnet := range excluded {
 			if subnet.Contains(i) {
 				isAddrExcluded = true
+				firstExcluded, _, _ := net.ParseCIDR(subnet.String())
+				_, lastExcluded, _ := GetIPRange(firstExcluded, *subnet)
+				if lastExcluded != nil {
+					if i.To4() != nil {
+						// exclude broadcast address
+						i = IPAddOffset(lastExcluded, uint64(1))
+					} else {
+						i = lastExcluded
+					}
+					logging.Debugf("excluding %v and moving to the next available ip: %v", subnet, i)
+				}
 			}
 		}
 		if isAddrExcluded {

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -2,11 +2,12 @@ package allocate
 
 import (
 	"fmt"
-	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 	"math"
 	"math/big"
 	"net"
 	"testing"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -324,6 +325,69 @@ var _ = Describe("Allocation operations", func() {
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
 
+	})
+
+	It("can IterateForAssignment on an IPv4 address excluding a range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"192.168.0.0/30"}
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
+
+	})
+
+	It("can IterateForAssignment on an IPv6 address excluding a range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("100::2:1/125")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"100::2:1/126"}
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
+
+	})
+
+	It("can IterateForAssignment on an IPv6 address excluding a very large range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("2001:db8::/32")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"2001:db8::0/30"}
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("2001:dbc::"))
+
+	})
+
+	It("can IterateForAssignment on an IPv4 address excluding unsorted ranges", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/28")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"192.168.0.0/30", "192.168.0.6/31", "192.168.0.8/31", "192.168.0.4/30"}
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
+
+		exrange = []string{"192.168.0.0/30", "192.168.0.14/31", "192.168.0.4/30", "192.168.0.6/31", "192.168.0.8/31"}
+		newip, _, _ = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
 	})
 
 	It("creates an IPv6 range properly for 96 bits network address", func() {


### PR DESCRIPTION
* prevent iterating complete excluded ranges

* Fix allocation test for large range skipping, err unused reported by staticcheck

* skip ranges >2 mask length

* Added unit tests for large ranges and unsorted ranges

Signed-off-by: nicklesimba <simha.nikhil@gmail.com>

Signed-off-by: nicklesimba <simha.nikhil@gmail.com>
Co-authored-by: Bram Verschueren <verschueren.bram@gmail.com>
Co-authored-by: dougbtv <dosmith@redhat.com>