### PR TITLE
Stop using the beta.kubernetes.io/arch

### DIFF
--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -72,7 +72,7 @@ spec:
       hostNetwork: true      
       serviceAccountName: whereabouts
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
Use kubernetes.io/arch instead

See https://github.com/kubernetes/kubernetes/issues/89477, https://github.com/kubernetes/kubernetes/issues/89477#issuecomment-603911496.