### PR TITLE
OCPBUGS-11322: respect requested allocation range when exluding ranges [Backport 4.13]

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -210,7 +210,7 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 	var assignedip net.IP
 	performedassignment := false
 	endip := IPAddOffset(lastip, uint64(1))
-	for i := firstip; !i.Equal(endip); i = IPAddOffset(i, uint64(1)) {
+	for i := firstip; ipnet.Contains(i) && !i.Equal(endip); i = IPAddOffset(i, uint64(1)) {
 		// if already reserved, skip it
 		if reserved[i.String()] {
 			continue

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -363,16 +363,16 @@ var _ = Describe("Allocation operations", func() {
 
 	It("can IterateForAssignment on an IPv6 address excluding a very large range", func() {
 
-		firstip, ipnet, err := net.ParseCIDR("2001:db8::/32")
+		firstip, ipnet, err := net.ParseCIDR("2001:db8::/30")
 		Expect(err).NotTo(HaveOccurred())
 
 		// figure out the range start.
 		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
 
 		var ipres []types.IPReservation
-		exrange := []string{"2001:db8::0/30"}
+		exrange := []string{"2001:db8::0/32"}
 		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
-		Expect(fmt.Sprint(newip)).To(Equal("2001:dbc::"))
+		Expect(fmt.Sprint(newip)).To(Equal("2001:db9::"))
 
 	})
 
@@ -392,6 +392,81 @@ var _ = Describe("Allocation operations", func() {
 		exrange = []string{"192.168.0.0/30", "192.168.0.14/31", "192.168.0.4/30", "192.168.0.6/31", "192.168.0.8/31"}
 		newip, _, _ = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
+	})
+
+	It("can IterateForAssignment on an IPv4 address excluding a range and respect the requested range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		ipres := []types.IPReservation{
+			{
+				IP:     net.ParseIP("192.168.0.4"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.5"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.6"),
+				PodRef: "default/pod1",
+			},
+		}
+		exrange := []string{"192.168.0.0/30"}
+		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
+
+	})
+	It("can IterateForAssignment on an IPv4 address excluding the last allocatable IP and respect the requested range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		ipres := []types.IPReservation{
+			{
+				IP:     net.ParseIP("192.168.0.1"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.2"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.3"),
+				PodRef: "default/pod1",
+			},
+		}
+		exrange := []string{"192.168.0.4/30"}
+		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
+
+	})
+
+	It("can IterateForAssignment on an IPv6 address excluding a range and respect the requested range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("100::2:1/125")
+		Expect(err).NotTo(HaveOccurred())
+
+		ipres := []types.IPReservation{
+			{
+				IP:     net.ParseIP("100::2:1"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("100::2:2"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("100::2:3"),
+				PodRef: "default/pod1",
+			},
+		}
+
+		exrange := []string{"100::2:4/126"}
+		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
+
 	})
 
 	It("creates an IPv6 range properly for 96 bits network address", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This prevent overflowing outside the requested ipam.range when excluding ranges while the requested range is exhausted.

Also corrects a test where we expected to assign an IP outside of the expected range.