### PR TITLE
[release-4.13] OCPBUGS-11424: Use downward API to pass current spec.nodeName to pod

### DIFF
--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -48,6 +48,11 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs:
+  - get
 - apiGroups: ["k8s.cni.cncf.io"]
   resources:
     - network-attachment-definitions
@@ -103,6 +108,11 @@ spec:
             /ip-control-loop -log-level debug
         image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
         env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
         - name: WHEREABOUTS_NAMESPACE
           valueFrom:
             fieldRef:

--- a/pkg/controlloop/dummy_controller.go
+++ b/pkg/controlloop/dummy_controller.go
@@ -5,11 +5,11 @@ package controlloop
 
 import (
 	"context"
-	kubeClient "github.com/k8snetworkplumbingwg/whereabouts/pkg/storage/kubernetes"
 	"net"
 
+	kubeClient "github.com/k8snetworkplumbingwg/whereabouts/pkg/storage/kubernetes"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1coreinformerfactory "k8s.io/client-go/informers"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -41,7 +41,10 @@ func newDummyPodController(
 	const noResyncPeriod = 0
 	netAttachDefInformerFactory := nadinformers.NewSharedInformerFactory(nadClient, noResyncPeriod)
 	wbInformerFactory := wbinformers.NewSharedInformerFactory(wbClient, noResyncPeriod)
-	podInformerFactory := v1coreinformerfactory.NewSharedInformerFactory(k8sClient, noResyncPeriod)
+	podInformerFactory, err := PodInformerFactory(k8sClient)
+	if err != nil {
+		return nil, err
+	}
 
 	podController := newPodController(
 		k8sClient,

--- a/pkg/controlloop/entity_generators.go
+++ b/pkg/controlloop/entity_generators.go
@@ -50,12 +50,23 @@ func dummyNonWhereaboutsIPAMNetSpec(networkName string) string {
     }`, networkName)
 }
 
-func podSpec(name string, namespace string, networks ...string) *v1.Pod {
+func nodeSpec(name string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func podSpec(name string, namespace string, nodeName string, networks ...string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: podNetworkSelectionElements(networks...),
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
 		},
 	}
 }

--- a/pkg/controlloop/pod_controller_test.go
+++ b/pkg/controlloop/pod_controller_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -57,20 +58,59 @@ var _ = Describe("IPControlLoop", func() {
 		Expect(os.RemoveAll(cniConfigDir)).To(Succeed())
 	})
 
-	Context("a running pod", func() {
+	Context("a running pod on a node", func() {
 		const (
 			networkName = "meganet"
 			podName     = "tiny-winy-pod"
+			nodeName    = "hypernode"
 		)
 
 		var (
-			k8sClient k8sclient.Interface
-			pod       *v1.Pod
+			k8sClient          k8sclient.Interface
+			pod                *v1.Pod
+			node               *v1.Node
+			dummyPodController *dummyPodController
+			podControllerError error
 		)
 
 		BeforeEach(func() {
-			pod = podSpec(podName, namespace, networkName)
-			k8sClient = fakek8sclient.NewSimpleClientset(pod)
+			pod = podSpec(podName, namespace, nodeName, networkName)
+			node = nodeSpec(nodeName)
+			k8sClient = fakek8sclient.NewSimpleClientset(pod, node)
+			os.Setenv("NODENAME", nodeName)
+		})
+
+		When("NODENAME is set to an invalid value", func() {
+			var (
+				wbClient           wbclient.Interface
+				eventRecorder      *record.FakeRecorder
+				netAttachDefClient nadclient.Interface
+				stopChannel        chan struct{}
+			)
+
+			BeforeEach(func() {
+				os.Setenv("NODENAME", "invalid-node-name")
+
+				stopChannel = make(chan struct{})
+				wbClient = fakewbclient.NewSimpleClientset()
+				netAttachDefClient, podControllerError = newFakeNetAttachDefClient(namespace, netAttachDef(networkName, namespace, dummyNonWhereaboutsIPAMNetSpec(networkName)))
+				Expect(podControllerError).NotTo(HaveOccurred())
+
+				const maxEvents = 1
+				eventRecorder = record.NewFakeRecorder(maxEvents)
+			})
+
+			It("should fail", func() {
+				_, podControllerError = newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)
+				Expect(errors.IsNotFound(podControllerError)).Should(BeTrue())
+			})
+
+			AfterEach(func() {
+				if podControllerError != nil {
+					return
+				}
+				stopChannel <- struct{}{}
+			})
 		})
 
 		Context("IPPool featuring an allocation for the pod", func() {
@@ -99,7 +139,10 @@ var _ = Describe("IPControlLoop", func() {
 					const maxEvents = 10
 					stopChannel = make(chan struct{})
 					eventRecorder = record.NewFakeRecorder(maxEvents)
-					Expect(newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)).NotTo(BeNil())
+
+					dummyPodController, podControllerError = newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)
+					Expect(podControllerError).NotTo(HaveOccurred())
+					Expect(dummyPodController).NotTo(BeNil())
 
 					// assure the pool features an allocated address
 					ipPool, err := wbClient.WhereaboutsV1alpha1().IPPools(dummyNetworkPool.GetNamespace()).Get(context.TODO(), dummyNetworkPool.GetName(), metav1.GetOptions{})
@@ -108,6 +151,9 @@ var _ = Describe("IPControlLoop", func() {
 				})
 
 				AfterEach(func() {
+					if podControllerError != nil {
+						return
+					}
 					stopChannel <- struct{}{}
 				})
 
@@ -146,7 +192,9 @@ var _ = Describe("IPControlLoop", func() {
 
 					const maxEvents = 10
 					eventRecorder = record.NewFakeRecorder(maxEvents)
-					Expect(newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)).NotTo(BeNil())
+					dummyPodController, podControllerError = newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)
+					Expect(podControllerError).NotTo(HaveOccurred())
+					Expect(dummyPodController).NotTo(BeNil())
 
 					// assure the pool features an allocated address
 					ipPool, err := wbClient.WhereaboutsV1alpha1().IPPools(dummyNetworkPool.GetNamespace()).Get(context.TODO(), dummyNetworkPool.GetName(), metav1.GetOptions{})
@@ -197,10 +245,16 @@ var _ = Describe("IPControlLoop", func() {
 
 				const maxEvents = 1
 				eventRecorder = record.NewFakeRecorder(maxEvents)
-				Expect(newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)).NotTo(BeNil())
+
+				dummyPodController, podControllerError = newDummyPodController(k8sClient, wbClient, netAttachDefClient, stopChannel, cniConfigDir, eventRecorder)
+				Expect(podControllerError).NotTo(HaveOccurred())
+				Expect(dummyPodController).NotTo(BeNil())
 			})
 
 			AfterEach(func() {
+				if podControllerError != nil {
+					return
+				}
 				stopChannel <- struct{}{}
 			})
 


### PR DESCRIPTION
The podInformerFactory uses filter key spec.nodeName to filter the pods that it should monitor. Up until now, this filter was set to the value of HOSTNAME. However, this is not reliable, as spec.nodeName can be overridden in kubernetes with --hostname-override and thus HOSTNAME and spec.nodeName do not necessarily always match. Instead, rely on a new custom environment variable NODENAME which is populated by the downward API.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit ef409bbf9caaaa600758b12ce1a5489107277a98)

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

