### PR TITLE
Restores RHEL specific binary build in dockerfile and updates to rhel9/8

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,11 +1,4 @@
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# This dockerfile is used for building for OpenShift
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS rhel9
 ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
 ENV CGO_ENABLED=1
@@ -14,11 +7,26 @@ RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
 RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.13
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS rhel8
+ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
+WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
+ENV CGO_ENABLED=1
+ENV GO111MODULE=on
+RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
+RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
+WORKDIR /
+
+FROM registry.ci.openshift.org/ocp/4.13:base
 RUN mkdir -p /usr/src/whereabouts/images && \
-       mkdir -p /usr/src/whereabouts/bin
-COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
-COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
+       mkdir -p /usr/src/whereabouts/bin && \
+       mkdir -p /usr/src/whereabouts/rhel9/bin && \
+       mkdir -p /usr/src/whereabouts/rhel8/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel8/bin
 
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
 LABEL io.k8s.display-name="Whereabouts CNI" \


### PR DESCRIPTION
Now that the binary is being dynamically compiled downstream, the binary must match the RHEL version of RHCOS because it is copied to the host.