### PR TITLE
Bug 16002: Change default binary to RHEL8 image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,21 +1,3 @@
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
-# URGENT! ART metadata configuration has a different number of FROMs
-# than this Dockerfile. ART will be unable to build your component or
-# reconcile this Dockerfile until that disparity is addressed.
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS rhel9
 ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
@@ -39,9 +21,9 @@ RUN mkdir -p /usr/src/whereabouts/images && \
        mkdir -p /usr/src/whereabouts/bin && \
        mkdir -p /usr/src/whereabouts/rhel9/bin && \
        mkdir -p /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
 COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
 COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin


### PR DESCRIPTION
OCP4.13 container image is RHEL8 based image, so need to change default binary in /usr/src/whereabous/bin to RHEL8.

Cherry-pick of https://github.com/openshift/whereabouts-cni/pull/144