### PR TITLE
Revert "Merge pull request #172 from dcbw/4.14-bug-16002"

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,3 +1,21 @@
+# URGENT! ART metadata configuration has a different number of FROMs
+# than this Dockerfile. ART will be unable to build your component or
+# reconcile this Dockerfile until that disparity is addressed.
+# URGENT! ART metadata configuration has a different number of FROMs
+# than this Dockerfile. ART will be unable to build your component or
+# reconcile this Dockerfile until that disparity is addressed.
+# URGENT! ART metadata configuration has a different number of FROMs
+# than this Dockerfile. ART will be unable to build your component or
+# reconcile this Dockerfile until that disparity is addressed.
+# URGENT! ART metadata configuration has a different number of FROMs
+# than this Dockerfile. ART will be unable to build your component or
+# reconcile this Dockerfile until that disparity is addressed.
+# URGENT! ART metadata configuration has a different number of FROMs
+# than this Dockerfile. ART will be unable to build your component or
+# reconcile this Dockerfile until that disparity is addressed.
+# URGENT! ART metadata configuration has a different number of FROMs
+# than this Dockerfile. ART will be unable to build your component or
+# reconcile this Dockerfile until that disparity is addressed.
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS rhel9
 ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
@@ -21,9 +39,9 @@ RUN mkdir -p /usr/src/whereabouts/images && \
        mkdir -p /usr/src/whereabouts/bin && \
        mkdir -p /usr/src/whereabouts/rhel9/bin && \
        mkdir -p /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
 COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
 COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin


### PR DESCRIPTION
This reverts commit 7e454367b5994241feb5dc713065508c5534f8f3, reversing changes made to d5a9ab30408a2c9e1a1741436ff4633c69c56bd4.

Reverts https://github.com/openshift/whereabouts-cni/pull/172

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

multus pod is crashlooping with:
[time="2023-08-05T18:35:57Z" level=error msg="Cluster operator network Degraded is True with RolloutHung: DaemonSet \"/openshift-multus/multus\" rollout is not making progress - pod multus-5cfj2 is in CrashLoopBackOff State\nDaemonSet \"/openshift-multus/multus\" rollout is not making progress - pod multus-djtxw is in CrashLoopBackOff State\nDaemonSet \"/openshift-multus/multus\" rollout is not making progress - last change 2023-08-05T18:20:06Z"](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-gcp/1687883708800962560/artifacts/e2e-gcp/ipi-install-install/artifacts/.openshift_install-1691260557.log)

[2023-08-05T18:45:44.568265072Z /usr/src/multus-cni/bin/multus-daemon: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /usr/src/multus-cni/bin/multus-daemon)](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-gcp/1687883708800962560/artifacts/e2e-gcp/gather-must-gather/artifacts/must-gather/inspect.local.4646579181213606894/namespaces/openshift-multus/pods/multus-djtxw/kube-multus/kube-multus/logs/previous.log)

The [diff](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.14.0-0.nightly/release/4.14.0-0.nightly-2023-08-05-174731?from=4.14.0-0.nightly-2023-08-04-145153) between payload that last succeeded install and the current failures indicates [172](https://github.com/openshift/whereabouts-cni/pull/172) is new in the multus area.

We are testing this revert to see if we can verify installs work again.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem

