### PR TITLE
Setup for upstream testing

### DIFF
--- a/Dockerfile.test.openshift
+++ b/Dockerfile.test.openshift
@@ -1,0 +1,11 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS rhel9
+ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
+WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
+ENV CGO_ENABLED=1
+ENV GO111MODULE=on
+RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
+RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
+RUN go test -c e2e/e2e_test.go -o bin/e2e
+WORKDIR /
+
+

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ COMPUTE_NODES ?= 2
 
 OCI_BIN ?= docker
 
+USE_STATIC_CHECK ?= true
+
+
 build:
 	hack/build-go.sh
 
@@ -23,10 +26,13 @@ install-tools:
 	hack/install-kubebuilder-tools.sh
 
 test: build install-tools
-	hack/test-go.sh
+	hack/test-go.sh -u $(USE_STATIC_CHECK)
 
 kind:
 	hack/e2e-setup-kind-cluster.sh -n $(COMPUTE_NODES)
+
+upstream-test: build
+	hack/test-go.sh -u $(false)
 
 $(BIN_DIR):
 	@mkdir -p $(BIN_DIR)

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 # single test: go test -v ./pkg/storage/
 # without cache: go test -count=1 -v ./pkg/storage/
-set -e -x
+set -eo -x pipefail
+
+while true; do
+  case "$1" in
+    -u|--use-static-check)
+      USE_STATIC_CHECK=true
+      break
+      ;;
+    *)
+      echo "define argument -u (use static check)"
+      exit 1
+  esac
+done
 
 GO=${GO:-go}
 
@@ -10,16 +22,15 @@ ${GO} vet --tags=test ./cmd/... ./pkg/...
 
 BASEDIR=$(pwd)
 
-echo "Installing golang staticcheck ..."
-GOBIN=${BASEDIR}/bin go install honnef.co/go/tools/cmd/staticcheck@latest
+#if static check true run this
+echo USE_STATIC_CHECK=$USE_STATIC_CHECK
 
-echo "Running golang staticcheck ..."
-${BASEDIR}/bin/staticcheck --tags=test ./...
+if [ $USE_STATIC_CHECK ]
+then
+  echo "Installing golang staticcheck ..."
+  GOBIN=${BASEDIR}/bin go install honnef.co/go/tools/cmd/staticcheck@latest
+  echo "Running golang staticcheck ..."
+  ${BASEDIR}/bin/staticcheck --tags=test ./...
+fi
 
-echo "Running go tests..."
-KUBEBUILDER_ASSETS="$(pwd)/bin" ${GO} test \
-    --tags=test \
-    -v \
-    -covermode=count \
-    -coverprofile=coverage.out \
-    $(${GO} list ./... | grep -v e2e | tr "\n" " ")
+


### PR DESCRIPTION
Add a test dockerfile to be used in openshift release so that we can run unit tests and e2e tests against prs in openshift

Add a new makefile target for upstream tests
with the ability to skip the static check dowstream (this causes issues with the upstream tests running in containers so we need a way to bypass it)

cc @dougbtv 

