### PR TITLE
<Carry> OCPBUGS-45854: Add test dockerfile

### DIFF
--- a/Dockerfile.test.openshift
+++ b/Dockerfile.test.openshift
@@ -7,28 +7,6 @@ RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
 RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS rhel8
-ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
-WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
-ENV CGO_ENABLED=1
-ENV GO111MODULE=on
-RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
-RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
-WORKDIR /
-
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.18
-ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
-RUN mkdir -p /usr/src/whereabouts/images && \
-       mkdir -p /usr/src/whereabouts/bin && \
-       mkdir -p /usr/src/whereabouts/rhel9/bin && \
-       mkdir -p /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel8/bin
 
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
 LABEL io.k8s.display-name="Whereabouts CNI" \


### PR DESCRIPTION
To run e2e tests in prow cluster we need the entire whereabouts binary in the final image build. we want to add a dockerfile just for testing that we can use here that we dont use anywhere else since it takes the image size from ~600mb to ~1gb



