### PR TITLE
OKD: fix entrypoint.sh for new SCOS builds

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ case "${ID}" in
 	rhcos|scos)
 		rhelmajor=$(echo ${RHEL_VERSION} | cut -f 1 -d .)
 		;;
-	rhel)
+	rhel|centos)
 		rhelmajor=$(echo "${VERSION_ID}" | cut -f 1 -d .)
 		;;
 	fedora)


### PR DESCRIPTION
Builds of OKD starting with 4.16 are based on CentOS Stream but the images identify as centos in /etc/os-release:
```
NAME="CentOS Stream"
VERSION="9"
ID="centos"
VERSION_ID="9"
```
See also https://github.com/okd-project/okd/discussions/2060
