### PR TITLE
NP-1110: <Carry> Add test dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS rhel9
-ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
-WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
+ADD . /go/src/github.com/openshift/whereabouts
+WORKDIR /go/src/github.com/openshift/whereabouts
 ENV CGO_ENABLED=1
 ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
@@ -8,8 +8,8 @@ RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS rhel8
-ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
-WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
+ADD . /go/src/github.com/openshift/whereabouts
+WORKDIR /go/src/github.com/openshift/whereabouts
 ENV CGO_ENABLED=1
 ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
@@ -21,15 +21,15 @@ RUN mkdir -p /usr/src/whereabouts/images && \
        mkdir -p /usr/src/whereabouts/bin && \
        mkdir -p /usr/src/whereabouts/rhel9/bin && \
        mkdir -p /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
-COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel8/bin
+COPY --from=rhel8 /go/src/github.com/openshift/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
+COPY --from=rhel8 /go/src/github.com/openshift/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
+COPY --from=rhel8 /go/src/github.com/openshift/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
+COPY --from=rhel9 /go/src/github.com/openshift/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
+COPY --from=rhel9 /go/src/github.com/openshift/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
+COPY --from=rhel8 /go/src/github.com/openshift/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin
+COPY --from=rhel8 /go/src/github.com/openshift/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel8/bin
 
-LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
+LABEL org.opencontainers.image.source https://github.com/openshift/whereabouts
 LABEL io.k8s.display-name="Whereabouts CNI" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a cluster-wide IPAM CNI plugin." \
       io.openshift.tags="openshift" \

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -57,16 +57,4 @@ CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${G
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/ip-control-loop cmd/controlloop/*.go
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/node-slice-controller cmd/nodeslicecontroller/*.go
 
-echo "Current working directory: $(pwd)"
-echo "Golang version: $(go version)"
-echo "GOPATH: ${GOPATH:-not set}"
-echo "GO111MODULE: ${GO111MODULE:-not set}"
-echo "GOROOT: ${GOROOT:-not set}"
-echo "Environment PATH: $PATH"
-echo "Modules download directory: $(go env GOPATH)/pkg/mod"
-echo "Listing /go/src/github.com/k8snetworkplumbingwg/whereabouts"
-ls /path/ || true
-
-#temp just for testing
-echo "Done With Build"
 


### PR DESCRIPTION
To run e2e tests in prow cluster we need the entire whereabouts binary in the final image build. we want to add a dockerfile just for testing that we can use here that we dont use anywhere else since it takes the image size from ~600mb to ~1gb

rename dockerfile dirs to point to openshift instead of k8snetworkplumbingwg
