### PR TITLE
NP-1110: Allow go vet to be skipped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install-tools:
 test: build install-tools
 	hack/test-go.sh 
 
-test-skip-static: build
+test-skip-static: 
 	hack/test-go.sh --skip-static-check 
 
 kind:

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -24,19 +24,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo "Running go vet ..."
-${GO} vet --tags=test ./cmd/... ./pkg/...
+
 
 BASEDIR=$(pwd)
 
 if [ $SKIP_STATIC_CHECK ]
 then
     echo "Skipped golang staticcheck"
+    echo "Skipped go vet"
 else
   echo "Installing golang staticcheck ..."
   GOBIN=${BASEDIR}/bin go install honnef.co/go/tools/cmd/staticcheck@latest
   echo "Running golang staticcheck ..."
   ${BASEDIR}/bin/staticcheck --tags=test ./...
+
+  echo "Running go vet ..."
+  ${GO} vet --tags=test ./cmd/... ./pkg/...
 fi
 
 echo "Running go tests..."


### PR DESCRIPTION
Move go vet into skip static, go vet does not have permission to run in the ci cluster, which is where we call the make test-skip-static

