### PR TITLE
OCPBUGS-58360: Add nodeslicecontroller bin to dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -5,6 +5,7 @@ ENV CGO_ENABLED=1
 ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
 RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
+RUN go build -mod vendor -o bin/node-slice-controller cmd/nodeslicecontroller/node_slice_controller.go
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.18 AS rhel8
@@ -14,6 +15,7 @@ ENV CGO_ENABLED=1
 ENV GO111MODULE=on
 RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
 RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
+RUN go build -mod vendor -o bin/node-slice-controller cmd/nodeslicecontroller/node_slice_controller.go
 WORKDIR /
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.18
@@ -24,10 +26,13 @@ RUN mkdir -p /usr/src/whereabouts/images && \
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/entrypoint.sh       /usr/src/whereabouts/bin
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/bin
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/node-slice-controller /usr/src/whereabouts/bin
 COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel9/bin
 COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel9/bin
+COPY --from=rhel9 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/node-slice-controller /usr/src/whereabouts/rhel9/bin
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts     /usr/src/whereabouts/rhel8/bin
 COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop /usr/src/whereabouts/rhel8/bin
+COPY --from=rhel8 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/node-slice-controller /usr/src/whereabouts/rhel8/bin
 
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
 LABEL io.k8s.display-name="Whereabouts CNI" \


### PR DESCRIPTION
We need the nodeSliceController binary in the openshift dockerfile to allow the whereabouts controller to be built

