### PR TITLE
add .0 for go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/whereabouts
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Hermeto errors out if its missing the `.0` for go versions >= `1.22`

Task: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=68395398