### PR TITLE
The node slice controller should only process valid whereabouts confi…

### DIFF
--- a/pkg/node-controller/controller.go
+++ b/pkg/node-controller/controller.go
@@ -2,6 +2,7 @@ package node_controller
 
 import (
 	"context"
+	nativeerrors "errors"
 	"fmt"
 	"sort"
 	"time"
@@ -280,6 +281,10 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 		// Foo resource to be synced.
 		if err := c.syncHandler(ctx, key); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
+			if nativeerrors.Is(err, types.ErrNoIPRanges) {
+				logger.Info(fmt.Sprintf("Ignoring net-attach-def with no IP ranges '%s': %s", key, err.Error()))
+				return nil // Don't requeue
+			}
 			c.workqueue.AddRateLimited(key)
 			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
 		}
@@ -514,6 +519,11 @@ func (c *Controller) checkForMultiNadMismatch(name, namespace string) error {
 		return err
 	}
 
+	// We need a valid IPAM configuration for comparison.
+	if len(ipamConf.IPRanges) == 0 {
+		return fmt.Errorf("%w: %s/%s", types.ErrNoIPRanges, namespace, name)
+	}
+
 	nadList, err := c.nadLister.List(labels.Everything())
 	if err != nil {
 		return err
@@ -523,6 +533,11 @@ func (c *Controller) checkForMultiNadMismatch(name, namespace string) error {
 		if err != nil {
 			return err
 		}
+
+		if len(additionalIpamConf.IPRanges) == 0 {
+			continue // skip this net-attach-def, it has no ranges
+		}
+
 		if !checkIpamConfMatch(ipamConf, additionalIpamConf) {
 			return fmt.Errorf("found IPAM conf mismatch for network-attachment-definitions with same network name")
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -205,3 +206,5 @@ const (
 	// Deallocate operation identifier
 	Deallocate = 1
 )
+
+var ErrNoIPRanges = errors.New("no IP ranges in whereabouts config")


### PR DESCRIPTION


If a net-attach-def with a whereabouts configuration was missing ranges, a comparison of the missing property would cause the node slice controller to crash

(cherry picked from commit c903949fe3823dbc4cc2bdde25e84591efefc3ee)

--clean backport 

