### PR TITLE
[release-4.12] OCPBUGS-87213: Syncing CI Build Root image tag with the ART 4.12 stream

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-8-release-golang-1.19-openshift-4.12


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Updated the CI Build Root image tag for the 4.12 branch to align with Golang builder version 1.19 from the ART 4.12 stream.

Impact: This alignment ensures uniformity between Prow CI testing and ART build/shipment processes by locking them to the same Golang version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

