### PR TITLE
[release-4.15] OCPBUGS-87467: Syncing CI Build Root image tag and go version in go.mod with …

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.10
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/whereabouts
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
…ART 4.15 stream

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Updated the CI Build Root image tag for the 4.15 branch to align with Golang builder version 1.20 from the ART 4.15 stream.

Also go version in go.mod is also updated to 1.20 considering there is no harm in bumping it as go support backport compatibility and didn't see potential issues with it.

Impact: This alignment ensures uniformity between Prow CI testing and ART build/shipment processes by locking them to the same Golang version.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

