### PR TITLE
CORENET-7230: Update OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,37 @@
 reviewers:
-  - aneeshkp
-  - dougbtv
-  - zshi-redhat
   - fepan
-  - s1061123
   - maiqueb
   - bpickard22
-  - pliurh
+  - anuragthehatter
+  - arkadeepsen
+  - arghosh93
+  - asood-rh
+  - danwinship
+  - jcaamano
+  - jluhrsen
+  - jechen0648
+  - LionelJouin
+  - martinkennelly
+  - marty-power
+  - mattedallo
+  - miheer
+  - kyrtapz
+  - pperiyasamy
+  - raphaelvrosa
+  - SachinNinganure
+  - shreyasbe
+  - tssurya
+  - taanyas
+  - vinnie1110
+  - weliang1
+  - wizhaoredhat
 approvers:
-  - aneeshkp
-  - dougbtv
-  - zshi-redhat
   - fepan
-  - s1061123
   - maiqueb
   - bpickard22
-  - pliurh
+  - LionelJouin
+  - danwinship
+  - SchSeba
+  - wizhaoredhat
 component: "Networking"
 subcomponent: "multus"
-


### PR DESCRIPTION
Update OWNERS file - remove inactive and non-Red Hat members, add full corenetworking team as reviewers and updated approvers.

Removed: aneeshkp, dougbtv, zshi-redhat, s1061123, pliurh
Added reviewers: anuragthehatter, arkadeepsen, arghosh93, asood-rh, danwinship, jcaamano, jluhrsen, jc-chen, LionelJouin, martinkennelly, marty-power, mattedallo, miheer, kyrtapz, pperiyasamy, raphaelvrosa, SachinNinganure, shreyasbe, tssurya, taanyas, vinnie1110, weliang1, maiqueb, fepan
Added approvers: LionelJouin, danwinship, SchSeba, wizhaoredhat, bpickard22, fepan, maiqueb

Jira: https://issues.redhat.com/browse/CORENET-7230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the approval and review configuration for the Networking multus component, adjusting the lists of reviewers and approvers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->