### PR TITLE
[release-4.22] OCPBUGS-91951: Syncing CI Build Root image and dockerfile base image tags and go version in go.mod with ART 4.22 stream

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.20
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS rhel9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS rhel9
 ADD . /go/src/github.com/openshift/whereabouts
 WORKDIR /go/src/github.com/openshift/whereabouts
 ENV CGO_ENABLED=1
@@ -8,7 +8,7 @@ RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
 RUN go build -mod vendor -o bin/node-slice-controller cmd/nodeslicecontroller/node_slice_controller.go
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.24-openshift-4.20 AS rhel8
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.22 AS rhel8
 ADD . /go/src/github.com/openshift/whereabouts
 WORKDIR /go/src/github.com/openshift/whereabouts
 ENV CGO_ENABLED=1
@@ -18,7 +18,7 @@ RUN go build -mod vendor -o bin/ip-control-loop cmd/controlloop/controlloop.go
 RUN go build -mod vendor -o bin/node-slice-controller cmd/nodeslicecontroller/node_slice_controller.go
 WORKDIR /
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 RUN mkdir -p /usr/src/whereabouts/images && \
        mkdir -p /usr/src/whereabouts/bin && \
        mkdir -p /usr/src/whereabouts/rhel9/bin && \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/k8snetworkplumbingwg/whereabouts
 
-go 1.24.2
-
-toolchain go1.24.6
+go 1.25.9
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION


<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Updated the CI Build Root image tag for the 4.22 branch to align with Golang builder version 1.25 from the ART 4.22 stream.

Also bumps the Go version in go.mod to 1.25. This toolchain upgrade unblocks critical CVE fixes in our third-party dependencies that require higher Go versions.

Impact: This alignment ensures uniformity between Prow CI testing and ART build/shipment processes by locking them to the same Golang version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

